### PR TITLE
Make handling of directories/paths more explicit

### DIFF
--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -44,7 +44,7 @@ def module(key: str, *subkeys: str, ensure_exists: bool = True) -> Module:
     return Module.from_key(key, *subkeys, ensure_exists=ensure_exists)
 
 
-def join(key: str, *subkeys: str, ensure_exists: bool = True) -> Path:
+def join(key: str, *subkeys: str, name: Optional[str] = None, ensure_exists: bool = True) -> Path:
     """Return the home data directory for the given module.
 
     :param key:
@@ -53,6 +53,8 @@ def join(key: str, *subkeys: str, ensure_exists: bool = True) -> Path:
         the default home directory.
     :param subkeys:
         A sequence of additional strings to join
+    :param name:
+        The name of the file (optional) inside the folder
     :param ensure_exists:
         Should all directories be created automatically?
         Defaults to true.
@@ -60,7 +62,7 @@ def join(key: str, *subkeys: str, ensure_exists: bool = True) -> Path:
         The path of the directory or subdirectory for the given module.
     """
     _module = Module.from_key(key, ensure_exists=ensure_exists)
-    return _module.join(*subkeys, ensure_exists=ensure_exists)
+    return _module.join(*subkeys, name=name, ensure_exists=ensure_exists)
 
 
 def get(*args, **kwargs):

--- a/src/pystow/module.py
+++ b/src/pystow/module.py
@@ -146,7 +146,7 @@ class Module:
         """
         if name is None:
             name = name_from_url(url)
-        directory = self.join(*subkeys, name=name, ensure_exists=True)
+        path = self.join(*subkeys, name=name, ensure_exists=True)
         download(
             url=url,
             path=path,

--- a/src/pystow/module.py
+++ b/src/pystow/module.py
@@ -87,7 +87,12 @@ class Module:
         base = self.join(*subkeys, ensure_exists=False)
         return Module(base=base, ensure_exists=ensure_exists)
 
-    def join(self, *subkeys: str, ensure_exists: bool = True, suffix_check: bool = True) -> Path:
+    def join(
+        self,
+        *subkeys: str,
+        name: Optional[str] = None,
+        ensure_exists: bool = True,
+    ) -> Path:
         """Get a subdirectory of the current module.
 
         :param subkeys:
@@ -96,16 +101,17 @@ class Module:
         :param ensure_exists:
             Should all directories be created automatically?
             Defaults to true.
-        :param suffix_check:
-            Should the last part of the path be checked for a suffix (i.e., contains a dot)?
-            Turn off if your final directory is not a file name but does contain dots.
+        :param name:
+            The name of the file (optional) inside the folder
         :return:
             The path of the directory or subdirectory for the given module.
         """
         rv = self.base
         if subkeys:
             rv = rv.joinpath(*subkeys)
-        mkdir(rv, ensure_exists=ensure_exists, suffix_check=suffix_check)
+            mkdir(rv, ensure_exists=ensure_exists)
+        if name:
+            rv = rv.joinpath(name)
         return rv
 
     def get(self, *args, **kwargs):
@@ -140,8 +146,7 @@ class Module:
         """
         if name is None:
             name = name_from_url(url)
-        directory = self.join(*subkeys, ensure_exists=True, suffix_check=False)
-        path = directory / name
+        directory = self.join(*subkeys, name=name, ensure_exists=True)
         download(
             url=url,
             path=path,

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -82,13 +82,10 @@ def name_from_url(url: str) -> str:
     return name
 
 
-def mkdir(path: Path, ensure_exists: bool = True, suffix_check: bool = True) -> None:
+def mkdir(path: Path, ensure_exists: bool = True) -> None:
     """Make a directory (or parent directory if a file is given) if flagged with ``ensure_exists``."""
     if ensure_exists:
-        if suffix_check and path.suffix:  # if it looks like a file path
-            path.parent.mkdir(exist_ok=True, parents=True)
-        else:
-            path.mkdir(exist_ok=True, parents=True)
+        path.mkdir(exist_ok=True, parents=True)
 
 
 @contextlib.contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,24 +41,6 @@ class TestUtils(unittest.TestCase):
             mkdir(subdirectory, ensure_exists=True)
             self.assertTrue(subdirectory.exists())
 
-    def test_mkdir_file(self):
-        """Test for ensuring a directory for a :class:`Path` to a file."""
-        with tempfile.TemporaryDirectory() as directory:
-            directory = Path(directory)
-            subdirectory = directory / 'sd2'
-            self.assertFalse(subdirectory.exists())
-
-            path = subdirectory / 'test.tsv'
-            self.assertFalse(path.exists())
-
-            mkdir(path, ensure_exists=False)
-            self.assertFalse(subdirectory.exists())
-            self.assertFalse(path.exists())
-
-            mkdir(path, ensure_exists=True)
-            self.assertTrue(subdirectory.exists())
-            self.assertFalse(path.exists())
-
     def test_mock_envvar(self):
         """Test that environment variables can be mocked properly."""
         name, value = n(), n()


### PR DESCRIPTION
Closes #2 

This PR introduces the `name` keyword argument to `pystow.join` to make it possible to use directories with dots in their names. This wasn't possible before because old code was checking if there was a file extension to determine if a `pathlib.Path` was a directory or file path.