### PR TITLE
Ensure API completeness

### DIFF
--- a/src/pystow/__init__.py
+++ b/src/pystow/__init__.py
@@ -9,6 +9,10 @@ from .api import (  # noqa
     ensure_from_google,
     ensure_from_s3,
     ensure_json,
+    ensure_open,
+    ensure_open_gz,
+    ensure_open_lzma,
+    ensure_open_tarfile,
     ensure_open_zip,
     ensure_rdf,
     ensure_tar_df,
@@ -16,6 +20,7 @@ from .api import (  # noqa
     ensure_untar,
     ensure_zip_df,
     join,
+    joinpath_sqlite,
     module,
 )
 from .config_api import get_config, write_config  # noqa

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -11,9 +11,14 @@ from .module import Module
 __all__ = [
     "module",
     "join",
+    "joinpath_sqlite",
     # Downloader functions
     "ensure",
     "ensure_untar",
+    "ensure_open",
+    "ensure_open_gz",
+    "ensure_open_lzma",
+    "ensure_open_tarfile",
     "ensure_open_zip",
     # Processors
     "ensure_csv",
@@ -152,6 +157,29 @@ def ensure_untar(
 
 
 @contextmanager
+def ensure_open(
+    key: str,
+    *subkeys: str,
+    url: str,
+    name: Optional[str] = None,
+    force: bool = False,
+    download_kwargs: Optional[Mapping[str, Any]] = None,
+    mode: str = "r",
+    open_kwargs: Optional[Mapping[str, Any]] = None,
+):
+    _module = Module.from_key(key, ensure_exists=True)
+    yield _module.ensure_open(
+        *subkeys,
+        url=url,
+        name=name,
+        force=force,
+        download_kwargs=download_kwargs,
+        mode=mode,
+        open_kwargs=open_kwargs,
+    )
+
+
+@contextmanager
 def ensure_open_zip(
     key: str,
     *subkeys: str,
@@ -169,6 +197,73 @@ def ensure_open_zip(
         *subkeys,
         url=url,
         inner_path=inner_path,
+        name=name,
+        force=force,
+        download_kwargs=download_kwargs,
+        mode=mode,
+        open_kwargs=open_kwargs,
+    )
+
+
+@contextmanager
+def ensure_open_lzma(
+    key: str,
+    *subkeys: str,
+    url: str,
+    name: Optional[str] = None,
+    force: bool = False,
+    download_kwargs: Optional[Mapping[str, Any]] = None,
+    mode: str = "r",
+    open_kwargs: Optional[Mapping[str, Any]] = None,
+):
+    _module = Module.from_key(key, ensure_exists=True)
+    yield _module.ensure_open_lzma(
+        *subkeys,
+        url=url,
+        name=name,
+        force=force,
+        download_kwargs=download_kwargs,
+        mode=mode,
+        open_kwargs=open_kwargs,
+    )
+
+
+@contextmanager
+def ensure_open_tarfile(
+    key: str,
+    *subkeys: str,
+    url: str,
+    inner_path: str,
+    name: Optional[str] = None,
+    force: bool = False,
+    download_kwargs: Optional[Mapping[str, Any]] = None,
+):
+    _module = Module.from_key(key, ensure_exists=True)
+    yield _module.ensure_open_tarfile(
+        *subkeys,
+        url=url,
+        inner_path=inner_path,
+        name=name,
+        force=force,
+        download_kwargs=download_kwargs,
+    )
+
+
+@contextmanager
+def ensure_open_gz(
+    key: str,
+    *subkeys: str,
+    url: str,
+    name: Optional[str] = None,
+    force: bool = False,
+    download_kwargs: Optional[Mapping[str, Any]] = None,
+    mode: str = "rb",
+    open_kwargs: Optional[Mapping[str, Any]] = None,
+):
+    _module = Module.from_key(key, ensure_exists=True)
+    yield _module.ensure_open_gz(
+        *subkeys,
+        url=url,
         name=name,
         force=force,
         download_kwargs=download_kwargs,
@@ -509,3 +604,16 @@ def ensure_from_google(
     """
     _module = Module.from_key(key, ensure_exists=True)
     return _module.ensure_from_google(*subkeys, name=name, file_id=file_id, force=force)
+
+
+def joinpath_sqlite(key, *subkeys: str, name: str) -> str:
+    """Get an SQLite database connection string.
+
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param name: The name of the database file.
+    :return: A SQLite path string.
+    """
+    _module = Module.from_key(key, ensure_exists=True)
+    return _module.joinpath_sqlite(*subkeys, name=name)

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -167,6 +167,29 @@ def ensure_open(
     mode: str = "r",
     open_kwargs: Optional[Mapping[str, Any]] = None,
 ):
+    """Ensure a file is downloaded and open it.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param mode: The read mode, passed to :func:`lzma.open`
+    :param open_kwargs: Additional keyword arguments passed to :func:`lzma.open`
+
+    :yields: An open file object
+    """
     _module = Module.from_key(key, ensure_exists=True)
     yield _module.ensure_open(
         *subkeys,
@@ -216,6 +239,29 @@ def ensure_open_lzma(
     mode: str = "r",
     open_kwargs: Optional[Mapping[str, Any]] = None,
 ):
+    """Ensure a LZMA-compressed file is downloaded and open a file inside it.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param mode: The read mode, passed to :func:`lzma.open`
+    :param open_kwargs: Additional keyword arguments passed to :func:`lzma.open`
+
+    :yields: An open file object
+    """
     _module = Module.from_key(key, ensure_exists=True)
     yield _module.ensure_open_lzma(
         *subkeys,
@@ -238,6 +284,29 @@ def ensure_open_tarfile(
     force: bool = False,
     download_kwargs: Optional[Mapping[str, Any]] = None,
 ):
+    """Ensure a tar file is downloaded and open a file inside it.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param inner_path:
+        The relative path to the file inside the archive
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+
+    :yields: An open file object
+    """
     _module = Module.from_key(key, ensure_exists=True)
     yield _module.ensure_open_tarfile(
         *subkeys,
@@ -260,6 +329,29 @@ def ensure_open_gz(
     mode: str = "rb",
     open_kwargs: Optional[Mapping[str, Any]] = None,
 ):
+    """Ensure a gzipped file is downloaded and open a file inside it.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param mode: The read mode, passed to :func:`gzip.open`
+    :param open_kwargs: Additional keyword arguments passed to :func:`gzip.open`
+
+    :yields: An open file object
+    """
     _module = Module.from_key(key, ensure_exists=True)
     yield _module.ensure_open_gz(
         *subkeys,
@@ -609,6 +701,10 @@ def ensure_from_google(
 def joinpath_sqlite(key, *subkeys: str, name: str) -> str:
     """Get an SQLite database connection string.
 
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
     :param subkeys:
         A sequence of additional strings to join. If none are given,
         returns the directory for this module.

--- a/src/pystow/module.py
+++ b/src/pystow/module.py
@@ -8,6 +8,7 @@ import logging
 import lzma
 import os
 import tarfile
+import warnings
 import zipfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -143,7 +144,12 @@ class Module:
             rv = rv.submodule(*subkeys, ensure_exists=ensure_exists)
         return rv
 
-    def submodule(self, *subkeys: str, ensure_exists: bool = True) -> "Module":
+    def submodule(self, *args, **kwargs) -> "Module":
+        """Get a module for a subdirectory of the current module."""
+        warnings.warn("Use .module() instead", DeprecationWarning)
+        return self.module(*args, **kwargs)
+
+    def module(self, *subkeys: str, ensure_exists: bool = True) -> "Module":
         """Get a module for a subdirectory of the current module.
 
         :param subkeys:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,8 +20,16 @@ class TestExposed(unittest.TestCase):
             if not inspect.isfunction(func) or name in SKIP:
                 continue
             with self.subTest(name=name):
-                self.assertIn(name, pystow.api.__all__)
+                self.assertIn(
+                    name,
+                    pystow.api.__all__,
+                    msg=f"Module.{name} should be included in from `pystow.api.__all__`.",
+                )
+                self.assertTrue(
+                    hasattr(pystow.api, name),
+                    msg=f"`Module.{name} should be exposed as a top-level function in `pystow.api`.",
+                )
                 self.assertTrue(
                     hasattr(pystow, name),
-                    msg=f"Module.{name} is not accessible from `pystow.{name}`",
+                    msg=f"`pystow.api.{name}` should be imported in `pystow.__init__`.",
                 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,7 @@ import unittest
 import pystow
 from pystow import Module
 
-SKIP = {"submodule"}
+SKIP = {"submodule", "__init__"}
 
 
 class TestExposed(unittest.TestCase):
@@ -20,4 +20,8 @@ class TestExposed(unittest.TestCase):
             if not inspect.isfunction(func) or name in SKIP:
                 continue
             with self.subTest(name=name):
-                self.assertTrue(hasattr(pystow, name))
+                self.assertIn(name, pystow.api.__all__)
+                self.assertTrue(
+                    hasattr(pystow, name),
+                    msg=f"Module.{name} is not accessible from `pystow.{name}`",
+                )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+"""Test for API completeness."""
+
+import inspect
+import unittest
+
+import pystow
+from pystow import Module
+
+SKIP = {"submodule"}
+
+
+class TestExposed(unittest.TestCase):
+    """Test API exposure."""
+
+    def test_exposed(self):
+        """Test that all module-level functions also have a counterpart in the top-level API."""
+        for name, func in Module.__dict__.items():
+            if not inspect.isfunction(func) or name in SKIP:
+                continue
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(pystow, name))


### PR DESCRIPTION
This PR adds a test to make sure that all functions on the `Module` object have a counterpart in the top-level `pystow` API. This will help mitigate the issues that lead to #27 in the future.