### PR TITLE
Fully document pystow and pass darglint checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,9 @@ pandas =
     pandas
 aws =
     boto3
+tests =
+    coverage
+    pytest
 docs =
     sphinx
     sphinx-rtd-theme
@@ -114,5 +117,6 @@ exclude_lines =
 # Darglint Configuration #
 ##########################
 [darglint]
-docstring_style=sphinx
-strictness=short
+docstring_style = sphinx
+strictness = full
+# enable = DAR104

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -534,7 +534,28 @@ def ensure_tar_df(
     download_kwargs: Optional[Mapping[str, Any]] = None,
     read_csv_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    """Download a tar file and open an inner file as a dataframe with :mod:`pandas`."""
+    """Download a tar file and open an inner file as a dataframe with :mod:`pandas`.
+
+    :param key: The module name
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param inner_path:
+        The relative path to the file inside the archive
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
+    :returns: A dataframe
+
+    .. warning:: If you have lots of files to read in the same archive, it's better just to unzip first.
+    """
     _module = Module.from_key(key, ensure_exists=True)
     return _module.ensure_tar_df(
         *subkeys,
@@ -557,7 +578,28 @@ def ensure_tar_xml(
     download_kwargs: Optional[Mapping[str, Any]] = None,
     parse_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    """Download a tar file and open an inner XML file with :mod:`lxml`."""
+    """Download a tar file and open an inner file as an XML with :mod:`lxml`.
+
+    :param key: The module name
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param inner_path:
+        The relative path to the file inside the archive
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param parse_kwargs: Keyword arguments to pass through to :func:`lxml.etree.parse`.
+    :returns: An ElementTree object
+
+    .. warning:: If you have lots of files to read in the same archive, it's better just to unzip first.
+    """
     _module = Module.from_key(key, ensure_exists=True)
     return _module.ensure_tar_xml(
         *subkeys,
@@ -580,7 +622,27 @@ def ensure_zip_df(
     download_kwargs: Optional[Mapping[str, Any]] = None,
     read_csv_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    """Download a zip file and open an inner file as a dataframe with :mod:`pandas`."""
+    """Download a zip file and open an inner file as a dataframe with :mod:`pandas`.
+
+    :param key: The module name
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param inner_path:
+        The relative path to the file inside the archive
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
+    :return: A pandas DataFrame
+    :rtype: pandas.DataFrame
+    """
     _module = Module.from_key(key, ensure_exists=True)
     return _module.ensure_zip_df(
         *subkeys,
@@ -603,7 +665,29 @@ def ensure_zip_np(
     download_kwargs: Optional[Mapping[str, Any]] = None,
     load_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    """Download a zip file and open an inner file as an array with :mod:`numpy`."""
+    """Download a zip file and open an inner file as an array-like with :mod:`numpy`.
+
+    :param key: The module name
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param inner_path:
+        The relative path to the file inside the archive
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs:
+        Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param load_kwargs:
+        Additional keyword arguments that are passed through to :func:`read_zip_np`
+        and transitively to :func:`numpy.load`.
+    :returns: An array-like object
+    """
     _module = Module.from_key(key, ensure_exists=True)
     return _module.ensure_zip_np(
         *subkeys,

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -215,7 +215,31 @@ def ensure_open_zip(
     mode: str = "r",
     open_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    """Ensure a file is downloaded then open it with :mod:`zipfile`."""
+    """Ensure a file is downloaded then open it with :mod:`zipfile`.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param inner_path:
+        The relative path to the file inside the archive
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param mode: The read mode, passed to :func:`zipfile.open`
+    :param open_kwargs: Additional keyword arguments passed to :func:`zipfile.open`
+
+    :yields: An open file object
+    """
     _module = Module.from_key(key, ensure_exists=True)
     yield _module.ensure_open_zip(
         *subkeys,

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -308,6 +308,8 @@ def ensure_open_tarfile(
     name: Optional[str] = None,
     force: bool = False,
     download_kwargs: Optional[Mapping[str, Any]] = None,
+    mode: str = "r",
+    open_kwargs: Optional[Mapping[str, Any]] = None,
 ):
     """Ensure a tar file is downloaded and open a file inside it.
 
@@ -329,6 +331,8 @@ def ensure_open_tarfile(
         Should the download be done again, even if the path already exists?
         Defaults to false.
     :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :param mode: The read mode, passed to :func:`tarfile.open`
+    :param open_kwargs: Additional keyword arguments passed to :func:`tarfile.open`
 
     :yields: An open file object
     """
@@ -340,6 +344,8 @@ def ensure_open_tarfile(
         name=name,
         force=force,
         download_kwargs=download_kwargs,
+        mode=mode,
+        open_kwargs=open_kwargs,
     )
 
 

--- a/src/pystow/cache.py
+++ b/src/pystow/cache.py
@@ -6,6 +6,7 @@ import functools
 import json
 import logging
 import os
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -50,7 +51,7 @@ X = TypeVar("X")
 Getter = Callable[[], X]
 
 
-class Cached(Generic[X]):
+class Cached(Generic[X], ABC):
     """Caching decorator."""
 
     def __init__(
@@ -67,7 +68,11 @@ class Cached(Generic[X]):
         self.force = force
 
     def __call__(self, func: Getter[X]) -> Getter[X]:
-        """Apply this instance as a decorator."""
+        """Apply this instance as a decorator.
+
+        :param func: The function to wrap
+        :return: A wrapped function
+        """
 
         @functools.wraps(func)
         def _wrapped() -> X:
@@ -81,25 +86,34 @@ class Cached(Generic[X]):
 
         return _wrapped
 
+    @abstractmethod
     def load(self) -> X:
         """Load data from the cache (typically by opening a file at the given path)."""
-        raise NotImplementedError
 
+    @abstractmethod
     def dump(self, rv: X) -> None:
-        """Dump data to the cache (typically by opening a file at the given path)."""
-        raise NotImplementedError
+        """Dump data to the cache (typically by opening a file at the given path).
+
+        :param rv: The data to dump
+        """
 
 
 class CachedJSON(Cached[JSONType]):
     """Make a function lazily cache its return value as JSON."""
 
     def load(self) -> JSONType:
-        """Load data from the cache as JSON."""
+        """Load data from the cache as JSON.
+
+        :returns: A python object with JSON-like data from the cache
+        """
         with open(self.path) as file:
             return json.load(file)
 
     def dump(self, rv: JSONType) -> None:
-        """Dump data to the cache as JSON."""
+        """Dump data to the cache as JSON.
+
+        :param rv: The JSON data to dump
+        """
         with open(self.path, "w") as file:
             json.dump(rv, file, indent=2)
 
@@ -108,12 +122,18 @@ class CachedPickle(Cached[Any]):
     """Make a function lazily cache its return value as a pickle."""
 
     def load(self) -> Any:
-        """Load data from the cache as a pickle."""
+        """Load data from the cache as a pickle.
+
+        :returns: A python object loaded from the cache
+        """
         with open(self.path, "rb") as file:
             return pickle.load(file)
 
     def dump(self, rv: Any) -> None:
-        """Dump data to the cache as a pickle."""
+        """Dump data to the cache as a pickle.
+
+        :param rv: The arbitrary python object to dump
+        """
         with open(self.path, "wb") as file:
             pickle.dump(rv, file, protocol=pickle.HIGHEST_PROTOCOL)
 
@@ -122,12 +142,18 @@ class CachedCollection(Cached[List[str]]):
     """Make a function lazily cache its return value as file."""
 
     def load(self) -> List[str]:
-        """Load data from the cache as a list of strings."""
+        """Load data from the cache as a list of strings.
+
+        :returns: A list of strings loaded from the cache
+        """
         with open(self.path) as file:
             return [line.strip() for line in file]
 
-    def dump(self, rv: Any) -> None:
-        """Dump data to the cache as a list of strings."""
+    def dump(self, rv: List[str]) -> None:
+        """Dump data to the cache as a list of strings.
+
+        :param rv: The list of strings to dump
+        """
         with open(self.path, "w") as file:
             for line in rv:
                 print(line, file=file)  # noqa:T001
@@ -168,7 +194,10 @@ class CachedDataFrame(Cached["pd.DataFrame"]):
         self.read_csv_kwargs.setdefault("keep_default_na", False)
 
     def load(self) -> "pd.DataFrame":
-        """Load data from the cache as a dataframe."""
+        """Load data from the cache as a dataframe.
+
+        :returns: A dataframe loaded from the cache.
+        """
         import pandas as pd
 
         return pd.read_csv(
@@ -178,5 +207,8 @@ class CachedDataFrame(Cached["pd.DataFrame"]):
         )
 
     def dump(self, rv: "pd.DataFrame") -> None:
-        """Dump data to the cache as a dataframe."""
+        """Dump data to the cache as a dataframe.
+
+        :param rv: The dataframe to dump
+        """
         rv.to_csv(self.path, sep=self.sep, index=False)

--- a/src/pystow/cli.py
+++ b/src/pystow/cli.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 
 """Command line interface for PyStow."""
 

--- a/src/pystow/config_api.py
+++ b/src/pystow/config_api.py
@@ -23,12 +23,25 @@ CONFIG_NAME_DEFAULT = ".config"
 
 
 def get_name() -> str:
-    """Get the config home directory name."""
+    """Get the config home directory name.
+
+    :returns: The name of the pystow home directory, either loaded from
+        the :data:`CONFIG_NAME_ENVVAR`` environment variable or given by the default
+        value :data:`CONFIG_NAME_DEFAULT`.
+    """
     return os.getenv(CONFIG_NAME_ENVVAR, default=CONFIG_NAME_DEFAULT)
 
 
 def get_home(ensure_exists: bool = True) -> Path:
-    """Get the config home directory."""
+    """Get the config home directory.
+
+    :param ensure_exists: If true, ensures the directory is created
+    :returns: A path object representing the pystow home directory, as one of:
+
+        1. :data:`CONFIG_HOME_ENVVAR` environment variable or
+        3. The default directory constructed in the user's home directory plus what's
+           returned by :func:`get_name`.
+    """
     default = Path.home() / get_name()
     return getenv_path(CONFIG_HOME_ENVVAR, default, ensure_exists=ensure_exists)
 
@@ -109,7 +122,12 @@ def _cast(rv, dtype):
 
 
 def write_config(module: str, key: str, value: str) -> None:
-    """Write a configuration value."""
+    """Write a configuration value.
+
+    :param module: The name of the app (e.g., ``indra``)
+    :param key: The key of the configuration in the app
+    :param value: The value of the configuration in the app
+    """
     _get_cfp.cache_clear()
     cfp = ConfigParser()
     path = get_home() / f"{module}.ini"

--- a/src/pystow/module.py
+++ b/src/pystow/module.py
@@ -142,7 +142,7 @@ class Module:
         base = get_base(key, ensure_exists=False)
         rv = cls(base=base, ensure_exists=ensure_exists)
         if subkeys:
-            rv = rv.submodule(*subkeys, ensure_exists=ensure_exists)
+            rv = rv.module(*subkeys, ensure_exists=ensure_exists)
         return rv
 
     def submodule(self, *args, **kwargs) -> "Module":

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath
 from subprocess import check_output  # noqa: S404
-from typing import Any, Collection, Iterable, Mapping, Optional, Union
+from typing import Any, Collection, ContextManager, Iterable, Mapping, Optional, Union
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
 from uuid import uuid4
@@ -271,7 +271,7 @@ def mkdir(path: Path, ensure_exists: bool = True) -> None:
 
 
 @contextlib.contextmanager
-def mock_envvar(envvar: str, value: str):
+def mock_envvar(envvar: str, value: str) -> ContextManager[None]:
     """Mock the environment variable then delete it after the test is over."""
     os.environ[envvar] = value
     yield
@@ -279,22 +279,31 @@ def mock_envvar(envvar: str, value: str):
 
 
 @contextlib.contextmanager
-def mock_home():
+def mock_home() -> ContextManager[Path]:
     """Mock the PyStow home environment variable, yields the directory name."""
     with tempfile.TemporaryDirectory() as directory:
         with mock_envvar(PYSTOW_HOME_ENVVAR, directory):
-            yield directory
+            yield Path(directory)
 
 
 def getenv_path(envvar: str, default: Path, ensure_exists: bool = True) -> Path:
-    """Get an environment variable representing a path, or use the default."""
+    """Get an environment variable representing a path, or use the default.
+
+    :param envvar: The environmental variable name to check
+    :param default: The default path to return if the environmental variable is not set
+    :param ensure_exists: Should the directories leading to the path be created if they don't already exist?
+    :return: A path either specified by the environmental variable or by the default.
+    """
     rv = Path(os.getenv(envvar, default=default))
     mkdir(rv, ensure_exists=ensure_exists)
     return rv
 
 
 def n() -> str:
-    """Get a random string for testing."""
+    """Get a random string for testing.
+
+    :returns: A random string for testing purposes.
+    """
     return str(uuid4())
 
 

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath
 from subprocess import check_output  # noqa: S404
-from typing import Any, Collection, ContextManager, Iterable, Mapping, Optional, Union
+from typing import Any, Collection, Iterable, Iterator, Mapping, Optional, Union
 from urllib.parse import urlparse
 from urllib.request import urlretrieve
 from uuid import uuid4
@@ -290,7 +290,7 @@ def mkdir(path: Path, ensure_exists: bool = True) -> None:
 
 
 @contextlib.contextmanager
-def mock_envvar(envvar: str, value: str) -> ContextManager[None]:
+def mock_envvar(envvar: str, value: str) -> Iterator[None]:
     """Mock the environment variable then delete it after the test is over.
 
     :param envvar: The environment variable to mock
@@ -309,7 +309,7 @@ def mock_envvar(envvar: str, value: str) -> ContextManager[None]:
 
 
 @contextlib.contextmanager
-def mock_home() -> ContextManager[Path]:
+def mock_home() -> Iterator[Path]:
     """Mock the PyStow home environment variable, yields the directory name.
 
     :yield: The path to the temporary directory.

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -542,7 +542,14 @@ def read_rdf(path: Union[str, Path], **kwargs):
 
 
 def get_commit(org: str, repo: str, provider: str = "git") -> str:
-    """Get last commit hash for the given repo."""
+    """Get last commit hash for the given repo.
+
+    :param org: The GitHub organization or owner
+    :param repo: The GitHub repository name
+    :param provider: The method for getting the most recent commit
+    :raises ValueError: if an invalid provider is given
+    :returns: A commit hash's hex digest as a string
+    """
     if provider == "git":
         output = check_output(["git", "ls-remote", f"https://github.com/{org}/{repo}"])  # noqa
         lines = (line.strip().split("\t") for line in output.decode("utf8").splitlines())
@@ -552,7 +559,7 @@ def get_commit(org: str, repo: str, provider: str = "git") -> str:
         res_json = res.json()
         rv = res_json["commit"]["sha"]
     else:
-        raise NotImplementedError(f"invalid implementation: {provider}")
+        raise ValueError(f"invalid implementation: {provider}")
     return rv
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,11 +33,8 @@ commands =
     coverage xml
 passenv =
     HOME
-deps =
-    coverage
-    codecov
-    pytest
 extras =
+    tests
     pandas
 whitelist_externals =
     /bin/cat
@@ -75,7 +72,7 @@ description = Run the pre-commit tool
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8<4.0.0
+    flake8
     flake8-bandit
     flake8-colors
     flake8-docstrings


### PR DESCRIPTION
This PR switches the `darglint` mode from `short` to `full`, which imposes that everything actually has to be documented in full.