### PR TITLE
Generic ensure

### DIFF
--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -198,6 +198,8 @@ class Module:
         :param provider:
             The file provider. Will be run with the path as the first positional argument,
             if the file needs to be generated.
+        :param kwargs:
+            Additional keyword-based parameters passed to the provider.
 
         :raises ValueError:
             If the provider was called but the file was not created by it.


### PR DESCRIPTION
This PR adds another ensure method, which uses a user-provided callable to generate the file, if it is not present.