### PR TITLE
Adds ensure gunzip command for single files

### DIFF
--- a/src/pystow/__init__.py
+++ b/src/pystow/__init__.py
@@ -20,6 +20,7 @@ from .api import (  # noqa
     ensure_open_gz,
     ensure_open_lzma,
     ensure_open_sqlite,
+    ensure_open_sqlite_gz,
     ensure_open_tarfile,
     ensure_open_zip,
     ensure_pickle,

--- a/src/pystow/__init__.py
+++ b/src/pystow/__init__.py
@@ -14,6 +14,7 @@ from .api import (  # noqa
     ensure_excel,
     ensure_from_google,
     ensure_from_s3,
+    ensure_gunzip,
     ensure_json,
     ensure_open,
     ensure_open_gz,

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -295,7 +295,29 @@ def ensure_gunzip(
     autoclean: bool = True,
     download_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> Path:
-    """Ensure a file is downloaded and gunzipped."""
+    """Ensure a file is downloaded and gunzipped.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        <key>_HOME where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param autoclean: Should the zipped file be deleted?
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :return:
+        The path of the directory where the file that has been downloaded
+        gets extracted to
+    """
     _module = Module.from_key(key, ensure_exists=True)
     return _module.ensure_gunzip(
         *subkeys,

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -1480,11 +1480,56 @@ def ensure_open_sqlite(
     >>> import pystow
     >>> import pandas as pd
     >>> url = "https://s3.amazonaws.com/bbop-sqlite/hp.db"
+    >>> sql = "SELECT * FROM entailed_edge LIMIT 10"
     >>> with pystow.ensure_open_sqlite("test", url=url) as conn:
-    >>>     df = pd.read_sql(" <query> ", conn)
+    >>>     df = pd.read_sql(sql, conn)
     """
     _module = Module.from_key(key, ensure_exists=True)
     with _module.ensure_open_sqlite(
+        *subkeys, url=url, name=name, force=force, download_kwargs=download_kwargs
+    ) as yv:
+        yield yv
+
+
+@contextmanager
+def ensure_open_sqlite_gz(
+    key: str,
+    *subkeys: str,
+    url: str,
+    name: Optional[str] = None,
+    force: bool = False,
+    download_kwargs: Optional[Mapping[str, Any]] = None,
+):
+    """Ensure and connect to a gzipped SQLite database.
+
+    :param key:
+        The name of the module. No funny characters. The envvar
+        `<key>_HOME` where key is uppercased is checked first before using
+        the default home directory.
+    :param subkeys:
+        A sequence of additional strings to join. If none are given,
+        returns the directory for this module.
+    :param url:
+        The URL to download.
+    :param name:
+        Overrides the name of the file at the end of the URL, if given. Also
+        useful for URLs that don't have proper filenames with extensions.
+    :param force:
+        Should the download be done again, even if the path already exists?
+        Defaults to false.
+    :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+    :yields: An instance of :class:`sqlite3.Connection` from :func:`sqlite3.connect`
+
+    Example usage:
+    >>> import pystow
+    >>> import pandas as pd
+    >>> url = "https://s3.amazonaws.com/bbop-sqlite/hp.db.gz"
+    >>> sql = "SELECT * FROM entailed_edge LIMIT 10"
+    >>> with pystow.ensure_open_sqlite_gz("test", url=url) as conn:
+    >>>     df = pd.read_sql(sql, conn)
+    """
+    _module = Module.from_key(key, ensure_exists=True)
+    with _module.ensure_open_sqlite_gz(
         *subkeys, url=url, name=name, force=force, download_kwargs=download_kwargs
     ) as yv:
         yield yv

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -43,6 +43,7 @@ __all__ = [
     "ensure_from_google",
     # Downloader functions with postprocessing
     "ensure_untar",
+    "ensure_gunzip",
     # Downloader + opener functions
     "ensure_open",
     "ensure_open_gz",
@@ -282,6 +283,25 @@ def ensure_untar(
         force=force,
         download_kwargs=download_kwargs,
         extract_kwargs=extract_kwargs,
+    )
+
+
+def ensure_gunzip(
+    key: str,
+    *subkeys: str,
+    url: str,
+    name: Optional[str] = None,
+    force: bool = False,
+    download_kwargs: Optional[Mapping[str, Any]] = None,
+) -> Path:
+    """Ensure a file is downloaded and gunzipped."""
+    _module = Module.from_key(key, ensure_exists=True)
+    return _module.ensure_gunzip(
+        *subkeys,
+        url=url,
+        name=name,
+        force=force,
+        download_kwargs=download_kwargs,
     )
 
 

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -292,6 +292,7 @@ def ensure_gunzip(
     url: str,
     name: Optional[str] = None,
     force: bool = False,
+    autoclean: bool = True,
     download_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> Path:
     """Ensure a file is downloaded and gunzipped."""
@@ -301,6 +302,7 @@ def ensure_gunzip(
         url=url,
         name=name,
         force=force,
+        autoclean=autoclean,
         download_kwargs=download_kwargs,
     )
 

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -51,6 +51,7 @@ __all__ = [
     "ensure_open_tarfile",
     "ensure_open_zip",
     "ensure_open_sqlite",
+    "ensure_open_sqlite_gz",
     # Processors
     "ensure_csv",
     "ensure_custom",

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -274,7 +274,25 @@ class Module:
         autoclean: bool = True,
         download_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Path:
-        """Ensure a tar.gz file is downloaded and unarchived."""
+        """Ensure a tar.gz file is downloaded and unarchived.
+
+        :param subkeys:
+            A sequence of additional strings to join. If none are given,
+            returns the directory for this module.
+        :param url:
+            The URL to download.
+        :param name:
+            Overrides the name of the file at the end of the URL, if given. Also
+            useful for URLs that don't have proper filenames with extensions.
+        :param force:
+            Should the download be done again, even if the path already exists?
+            Defaults to false.
+        :param autoclean: Should the zipped file be deleted?
+        :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+        :return:
+            The path of the directory where the file that has been downloaded
+            gets extracted to
+        """
         if name is None:
             name = name_from_url(url)
         gunzipped_name = base_from_gzip_name(name)

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -1334,13 +1334,59 @@ class Module:
         >>> import pystow
         >>> import pandas as pd
         >>> url = "https://s3.amazonaws.com/bbop-sqlite/hp.db"
+        >>> sql = "SELECT * FROM entailed_edge LIMIT 10"
         >>> module = pystow.module("test")
         >>> with module.ensure_open_sqlite(url=url) as conn:
-        >>>     df = pd.read_sql(" <query> ", conn)
+        >>>     df = pd.read_sql(sql, conn)
         """
         import sqlite3
 
         path = self.ensure(
+            *subkeys, url=url, name=name, force=force, download_kwargs=download_kwargs
+        )
+        with closing(sqlite3.connect(path.as_posix())) as conn:
+            yield conn
+
+    @contextmanager
+    def ensure_open_sqlite_gz(
+        self,
+        *subkeys: str,
+        url: str,
+        name: Optional[str] = None,
+        force: bool = False,
+        download_kwargs: Optional[Mapping[str, Any]] = None,
+    ):
+        """Ensure and connect to a SQLite database that's gzipped.
+
+        Unfortunately, it's a paid feature to directly read gzipped sqlite files,
+        so this automatically gunzips it first.
+
+        :param subkeys:
+            A sequence of additional strings to join. If none are given,
+            returns the directory for this module.
+        :param url:
+            The URL to download.
+        :param name:
+            Overrides the name of the file at the end of the URL, if given. Also
+            useful for URLs that don't have proper filenames with extensions.
+        :param force:
+            Should the download be done again, even if the path already exists?
+            Defaults to false.
+        :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
+        :yields: An instance of :class:`sqlite3.Connection` from :func:`sqlite3.connect`
+
+        Example usage:
+        >>> import pystow
+        >>> import pandas as pd
+        >>> url = "https://s3.amazonaws.com/bbop-sqlite/hp.db.gz"
+        >>> module = pystow.module("test")
+        >>> sql = "SELECT * FROM entailed_edge LIMIT 10"
+        >>> with module.ensure_open_sqlite_gz(url=url) as conn:
+        >>>     df = pd.read_sql(sql, conn)
+        """
+        import sqlite3
+
+        path = self.ensure_gunzip(
             *subkeys, url=url, name=name, force=force, download_kwargs=download_kwargs
         )
         with closing(sqlite3.connect(path.as_posix())) as conn:

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -271,6 +271,7 @@ class Module:
         url: str,
         name: Optional[str] = None,
         force: bool = False,
+        autoclean: bool = True,
         download_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Path:
         """Ensure a tar.gz file is downloaded and unarchived."""
@@ -288,7 +289,9 @@ class Module:
             download_kwargs=download_kwargs,
         )
         gunzip(path, gunzipped_path)
-        # TODO cleanup of original file?
+        if autoclean:
+            logger.info("removing original gzipped file %s", path)
+            path.unlink()
         return gunzipped_path
 
     @contextmanager

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -938,4 +938,4 @@ def gunzip(source: Union[str, Path], target: Union[str, Path]) -> None:
     :param target: The path to an output file
     """
     with gzip.open(source, "rb") as in_file, open(target, "wb") as out_file:
-        out_file.write(in_file.read())
+        shutil.copyfileobj(in_file, out_file)

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -928,6 +928,11 @@ def path_to_sqlite(path: Union[str, Path]) -> str:
     return f"sqlite:///{path.as_posix()}"
 
 
-def gunzip(source, target) -> None:
-    """Unzip a file in the source to the target."""
-    raise NotImplementedError
+def gunzip(source: Union[str, Path], target: Union[str, Path]) -> None:
+    """Unzip a file in the source to the target.
+
+    :param source: The path to an input file
+    :param target: The path to an output file
+    """
+    with gzip.open(source, "rb") as in_file, open(target, "wb") as out_file:
+        out_file.write(in_file.read())

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -352,8 +352,11 @@ def name_from_url(url: str) -> str:
     return name
 
 
-def base_from_gzip_name(path: Union[str, Path]) -> str:
-    pass
+def base_from_gzip_name(name: Union[str, Path]) -> str:
+    """Get the base name for a file after stripping the gz ending."""
+    if not name.endswith(".gz"):
+        raise ValueError(f"Name does not end with .gz: {name}")
+    return name[: -len(".gz")]
 
 
 def name_from_s3_key(key: str) -> str:

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -352,8 +352,13 @@ def name_from_url(url: str) -> str:
     return name
 
 
-def base_from_gzip_name(name: Union[str, Path]) -> str:
-    """Get the base name for a file after stripping the gz ending."""
+def base_from_gzip_name(name: str) -> str:
+    """Get the base name for a file after stripping the gz ending.
+
+    :param name: The name of the gz file
+    :returns: The cleaned name of the file, with no gz ending
+    :raises ValueError: if the file does not end with ".gz"
+    """
     if not name.endswith(".gz"):
         raise ValueError(f"Name does not end with .gz: {name}")
     return name[: -len(".gz")]

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -57,6 +57,7 @@ __all__ = [
     "get_np_io",
     # LZMA utilities
     "write_lzma_csv",
+    "gunzip",
     # Zipfile utilities
     "write_zipfile_csv",
     "read_zipfile_csv",
@@ -349,6 +350,10 @@ def name_from_url(url: str) -> str:
     path = PurePosixPath(parse_result.path)
     name = path.name
     return name
+
+
+def base_from_gzip_name(path: Union[str, Path]) -> str:
+    pass
 
 
 def name_from_s3_key(key: str) -> str:
@@ -921,3 +926,8 @@ def path_to_sqlite(path: Union[str, Path]) -> str:
     """
     path = Path(path).expanduser().resolve()
     return f"sqlite:///{path.as_posix()}"
+
+
+def gunzip(source, target) -> None:
+    """Unzip a file in the source to the target."""
+    raise NotImplementedError


### PR DESCRIPTION
Closes #45

This supports ensuring/unzipping GZ files. In addition, it wraps the sqlite opener for use cases like the following:

```python
import pandas as pd

import pystow

if __name__ == "__main__":
    sql = "SELECT * FROM entailed_edge LIMIT 10"
    url = "https://s3.amazonaws.com/bbop-sqlite/hp.db.gz"
    with pystow.ensure_open_sqlite_gz("test", url=url) as conn:
        df = pd.read_sql(sql, conn)
    print(df)
```