### PR TITLE
Add progress bars for downloading

### DIFF
--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -298,7 +298,7 @@ def download(
     hexdigests: Optional[Mapping[str, str]] = None,
     hexdigests_remote: Optional[Mapping[str, str]] = None,
     hexdigests_strict: bool = False,
-    progress_bar: bool = True,
+    progress_bar: bool = False,
     tqdm_kwargs: Optional[Mapping[str, Any]] = None,
     **kwargs: Any,
 ) -> None:

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -274,8 +274,8 @@ class TqdmReportHook(tqdm):
 
     def update_to(
         self,
-        blocks: Optional[int] = 1,
-        block_size: Optional[int] = 1,
+        blocks: int = 1,
+        block_size: int = 1,
         total_size: Optional[int] = None,
     ) -> None:
         """Update the internal state based on a urllib report hook.

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -14,8 +14,8 @@ import tarfile
 import tempfile
 import zipfile
 from collections import namedtuple
-from io import BytesIO, StringIO
 from functools import partial
+from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath
 from subprocess import check_output  # noqa: S404
 from typing import Any, Collection, Iterable, Iterator, Mapping, Optional, Union


### PR DESCRIPTION
Closes #60

- [x] `urllib` support (inspired by https://gist.github.com/leimao/37ff6e990b3226c2c9670a2cd1e4a6f5)
- [x] `requests` support (inspired by https://stackoverflow.com/a/63831344/5775947)

Example usage:

```python
import pystow

if __name__ == '__main__':
    url = "https://zenodo.org/record/7633479/files/emojis.zip?download=1"
    path = pystow.ensure(
        "test",
        force=True,
        url=url,
        name="emojis.zip",
        download_kwargs=dict(progress_bar=True, backend="requests", tqdm_kwargs=dict(leave=True)),
    )
    print("download succeeded to ", path)
```