### PR TITLE
Improve permission error text

### DIFF
--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -1007,7 +1007,15 @@ def get_base(key: str, ensure_exists: bool = True) -> Path:
 
 def ensure_readme() -> None:
     """Ensure there's a README in the PyStow data directory."""
-    readme_path = get_home(ensure_exists=True).joinpath("README.md")
+    try:
+        readme_path = get_home(ensure_exists=True).joinpath("README.md")
+    except PermissionError as e:
+        raise PermissionError(
+            f"PyStow was not able to create its home directory in {readme_path.parent} due to a lack of "
+            "permissions. This can happen, e.g., if you're working on a server where you don't have full "
+            "rights. See https://pystow.readthedocs.io/en/latest/installation.html#configuration for instructions "
+            "on choosing a different home folder location for PyStow to somewhere where you have write permissions."
+        ) from e
     if readme_path.is_file():
         return
     with readme_path.open("w", encoding="utf8") as file:

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -1006,7 +1006,11 @@ def get_base(key: str, ensure_exists: bool = True) -> Path:
 
 
 def ensure_readme() -> None:
-    """Ensure there's a README in the PyStow data directory."""
+    """Ensure there's a README in the PyStow data directory.
+
+    :raises PermissionError: If the script calling this function does not have
+        adequate permissions to write a file into the PyStow home directory.
+    """
     try:
         readme_path = get_home(ensure_exists=True).joinpath("README.md")
     except PermissionError as e:


### PR DESCRIPTION
I was sent the following traceback which seems to correspond to someone who is using the Bioregistry, which has PyStow as a transitive dependency. They call code that invokes the Bioregistry, which imports PyStow and tries to create a README file in its default folder. However, the default folder is created in the home directory of the server, which is `/var/www`, and this user doesn't have permission to write in that folder.

Therefore, the solution is to change the PyStow configuration to overwrite the default location and pick somewhere where the user has write privileges. Changing the default Pystow location can be done by following instructions here: https://pystow.readthedocs.io/en/latest/installation.html#configuration

```python-traceback
Traceback (most recent call last): File "signorValidator.py", line 5, in #import bioregistry File "/usr/local/lib/python3.8/dist-packages/bioregistry/__init__.py", line 5, in from .collection_api import get_collection, get_context # noqa:F401 File "/usr/local/lib/python3.8/dist-packages/bioregistry/collection_api.py", line 7, in from .resource_manager import manager File "/usr/local/lib/python3.8/dist-packages/bioregistry/resource_manager.py", line 27, in from .constants import ( File "/usr/local/lib/python3.8/dist-packages/bioregistry/constants.py", line 10, in import pystow File "/usr/local/lib/python3.8/dist-packages/pystow/__init__.py", line 53, in ensure_readme() File "/usr/local/lib/python3.8/dist-packages/pystow/utils.py", line 1010, in ensure_readme readme_path = get_home(ensure_exists=True).joinpath("README.md") File "/usr/local/lib/python3.8/dist-packages/pystow/utils.py", line 978, in get_home return getenv_path(PYSTOW_HOME_ENVVAR, default, ensure_exists=ensure_exists) File "/usr/local/lib/python3.8/dist-packages/pystow/utils.py", line 475, in getenv_path mkdir(rv, ensure_exists=ensure_exists) File "/usr/local/lib/python3.8/dist-packages/pystow/utils.py", line 433, in mkdir path.mkdir(exist_ok=True, parents=True) File "/usr/lib/python3.8/pathlib.py", line 1288, in mkdir self._accessor.mkdir(self, mode) PermissionError: [Errno 13] Permission denied: '/var/www/.data'
```