### PR TITLE
Add initial support for version handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     click
     requests
     tqdm
-    typing_extensions; python_version < "3.10"
+    typing_extensions
 
 zip_safe = false
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     click
     requests
     tqdm
-    typing_extensions; python<=3.9
+    typing_extensions; "python <= 3.9"
 
 zip_safe = false
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     click
     requests
     tqdm
-    typing_extensions; "python <= 3.9"
+    typing_extensions; python_version < "3.10"
 
 zip_safe = false
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     click
     requests
     tqdm
-    typing_extensions ; python < 3.10
+    typing_extensions; python<=3.9
 
 zip_safe = false
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     click
     requests
     tqdm
+    typing_extensions ; python < 3.10
 
 zip_safe = false
 python_requires = >=3.9

--- a/src/pystow/__init__.py
+++ b/src/pystow/__init__.py
@@ -47,7 +47,7 @@ from .api import (
     open_gz,
 )
 from .config_api import ConfigError, get_config, write_config
-from .impl import Module
+from .impl import Module, VersionHint
 from .utils import ensure_readme
 
 __all__ = [
@@ -97,6 +97,7 @@ __all__ = [
     "get_config",
     "write_config",
     "Module",
+    "VersionHint",
 ]
 
 ensure_readme()

--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -128,7 +128,7 @@ def join(
             # Assume you want to download the data from
             # ftp://ftp.expasy.org/databases/rhea/rdf/rhea.rdf.gz, make a path
             # with the same name
-            path = pystow.join(name="rhea.rdf.gz", version=get_rhea_version)
+            path = pystow.join("rhea", name="rhea.rdf.gz", version=get_rhea_version)
 
     :return:
         The path of the directory or subdirectory for the given module.
@@ -216,6 +216,29 @@ def ensure(
     :param name:
         Overrides the name of the file at the end of the URL, if given. Also
         useful for URLs that don't have proper filenames with extensions.
+    :param version:
+        The optional version, or no-argument callable that returns
+        an optional version. This is prepended before the subkeys.
+
+        The following example describes how to store the versioned data
+        from the Rhea database for biologically relevant chemical reactions.
+
+        .. code-block::
+
+            import pystow
+            import requests
+
+            def get_rhea_version() -> str:
+                res = requests.get("https://ftp.expasy.org/databases/rhea/rhea-release.properties")
+                _, _, version = res.text.splitlines()[0].partition("=")
+                return version
+
+            path = pystow.ensure(
+                "rhea",
+                url="ftp://ftp.expasy.org/databases/rhea/rdf/rhea.rdf.gz",
+                version=get_rhea_version,
+            )
+
     :param force:
         Should the download be done again, even if the path already exists?
         Defaults to false.

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -11,7 +11,6 @@ import lzma
 import os
 import pickle
 import sqlite3
-import sys
 import tarfile
 import zipfile
 from contextlib import closing, contextmanager
@@ -31,6 +30,8 @@ from typing import (
     overload,
 )
 
+from typing_extensions import TypeAlias
+
 from . import utils
 from .constants import JSON, BytesOpener, Provider
 from .utils import (
@@ -49,11 +50,6 @@ from .utils import (
     read_zip_np,
     read_zipfile_csv,
 )
-
-if sys.version_info <= (3, 9):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias
 
 if TYPE_CHECKING:
     import botocore.client

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -170,7 +170,7 @@ class Module:
             version = version()
         if version:
             self._raise_for_invalid_version(version)
-            subkeys = [version, *subkeys]
+            subkeys = (version, *subkeys)
 
         if subkeys:
             rv = rv.joinpath(*subkeys)
@@ -187,7 +187,8 @@ class Module:
             )
         if os.sep in version:
             raise ValueError(
-                f"path separator `{os.sep}` not allowed in versions because of conflicts with file path construction: {version}"
+                f"path separator `{os.sep}` not allowed in versions because of "
+                f"conflicts with file path construction: {version}"
             )
 
     def joinpath_sqlite(self, *subkeys: str, name: str) -> str:

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -58,7 +58,10 @@ if TYPE_CHECKING:
     import pandas as pd
     import rdflib
 
-__all__ = ["Module"]
+__all__ = [
+    "Module",
+    "VersionHint",
+]
 
 logger = logging.getLogger(__name__)
 

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -183,11 +183,7 @@ class Module:
     def _raise_for_invalid_version(version: str) -> None:
         if "/" in version or os.sep in version:
             raise ValueError(
-                f"slashes not allowed in versions because of conflicts with file path construction: {version}"
-            )
-        if os.sep in version:
-            raise ValueError(
-                f"path separator `{os.sep}` not allowed in versions because of "
+                f"slashes and `{os.sep}` not allowed in versions because of "
                 f"conflicts with file path construction: {version}"
             )
 

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -7,6 +7,7 @@ import gzip
 import json
 import logging
 import lzma
+import os
 import sqlite3
 import tarfile
 import zipfile
@@ -15,11 +16,13 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Generator,
     Mapping,
     Optional,
     Sequence,
+    TypeAlias,
     Union,
 )
 
@@ -57,6 +60,10 @@ if TYPE_CHECKING:
 __all__ = ["Module"]
 
 logger = logging.getLogger(__name__)
+
+#: A type hint for something that can be passed to the
+#: `version` argument of Module.join, Module.ensure, etc.
+VersionHint: TypeAlias = Union[None, str, Callable[[], Optional[str]]]
 
 
 class Module:
@@ -117,6 +124,7 @@ class Module:
         *subkeys: str,
         name: Optional[str] = None,
         ensure_exists: bool = True,
+        version: VersionHint = None,
     ) -> Path:
         """Get a subdirectory of the current module.
 
@@ -128,16 +136,59 @@ class Module:
             Defaults to true.
         :param name:
             The name of the file (optional) inside the folder
+        :param version:
+            The optional version, or no-argument callable that returns
+            an optional version. This is prepended before the subkeys.
+
+            The following example describes how to store the versioned data
+            from the Rhea database for biologically relevant chemical reactions.
+
+            .. code-block::
+
+                import pystow
+                import requests
+
+                def get_rhea_version() -> str:
+                    res = requests.get("https://ftp.expasy.org/databases/rhea/rhea-release.properties")
+                    _, _, version = res.text.splitlines()[0].partition("=")
+                    return version
+
+                # Assume you want to download the data from
+                # ftp://ftp.expasy.org/databases/rhea/rdf/rhea.rdf.gz, make a path
+                # with the same name
+                module = pystow.module("rhea")
+                path = module.join(name="rhea.rdf.gz", version=get_rhea_version)
+
         :return:
             The path of the directory or subdirectory for the given module.
         """
         rv = self.base
+
+        # if the version is given as a no-argument callable,
+        # then it should be called and a version is returned
+        if callable(version):
+            version = version()
+        if version:
+            self._raise_for_invalid_version(version)
+            subkeys = [version, *subkeys]
+
         if subkeys:
             rv = rv.joinpath(*subkeys)
             mkdir(rv, ensure_exists=ensure_exists)
         if name:
             rv = rv.joinpath(name)
         return rv
+
+    @staticmethod
+    def _raise_for_invalid_version(version: str) -> None:
+        if "/" in version or os.sep in version:
+            raise ValueError(
+                f"slashes not allowed in versions because of conflicts with file path construction: {version}"
+            )
+        if os.sep in version:
+            raise ValueError(
+                f"path separator `{os.sep}` not allowed in versions because of conflicts with file path construction: {version}"
+            )
 
     def joinpath_sqlite(self, *subkeys: str, name: str) -> str:
         """Get an SQLite database connection string.
@@ -156,6 +207,7 @@ class Module:
         *subkeys: str,
         url: str,
         name: Optional[str] = None,
+        version: VersionHint = None,
         force: bool = False,
         download_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Path:
@@ -169,6 +221,29 @@ class Module:
         :param name:
             Overrides the name of the file at the end of the URL, if given. Also
             useful for URLs that don't have proper filenames with extensions.
+        :param version:
+            The optional version, or no-argument callable that returns
+            an optional version. This is prepended before the subkeys.
+
+            The following example describes how to store the versioned data
+            from the Rhea database for biologically relevant chemical reactions.
+
+            .. code-block::
+
+                import pystow
+                import requests
+
+                def get_rhea_version() -> str:
+                    res = requests.get("https://ftp.expasy.org/databases/rhea/rhea-release.properties")
+                    _, _, version = res.text.splitlines()[0].partition("=")
+                    return version
+
+                module = pystow.module("rhea")
+                path = module.ensure(
+                    url="ftp://ftp.expasy.org/databases/rhea/rdf/rhea.rdf.gz",
+                    version=get_rhea_version,
+                )
+
         :param force:
             Should the download be done again, even if the path already exists?
             Defaults to false.
@@ -178,7 +253,7 @@ class Module:
         """
         if name is None:
             name = name_from_url(url)
-        path = self.join(*subkeys, name=name, ensure_exists=True)
+        path = self.join(*subkeys, name=name, version=version, ensure_exists=True)
         utils.download(
             url=url,
             path=path,

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -22,7 +22,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    TypeAlias,
     Union,
 )
 
@@ -46,9 +45,9 @@ from .utils import (
 )
 
 try:
-    import pickle5 as pickle
+    from typing import TypeAlias
 except ImportError:
-    import pickle
+    from typing_extensions import TypeAlias
 
 if TYPE_CHECKING:
     import botocore.client

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -8,6 +8,7 @@ import json
 import logging
 import lzma
 import os
+import pickle
 import sqlite3
 import tarfile
 import zipfile

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -11,6 +11,7 @@ import lzma
 import os
 import pickle
 import sqlite3
+import sys
 import tarfile
 import zipfile
 from contextlib import closing, contextmanager
@@ -49,10 +50,10 @@ from .utils import (
     read_zipfile_csv,
 )
 
-try:
-    from typing import TypeAlias
-except ImportError:
+if sys.version_info <= (3, 9):
     from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 if TYPE_CHECKING:
     import botocore.client

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -225,6 +225,9 @@ class TestJoin(unittest.TestCase):
                 pystow.join(key, *parts, version=_version_getter, name=name),
             )
 
+            with self.assertRaises(ValueError):
+                pystow.join(key, version="/")
+
     def test_ensure(self):
         """Test ensuring various files."""
         write_pickle_gz(TEST_TSV_ROWS, path=PICKLE_GZ_PATH)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -60,7 +60,6 @@ JSON_BZ2_NAME = "test_1.json.bz2"
 JSON_BZ2_URL = f"{n()}/{JSON_BZ2_NAME}"
 JSON_BZ2_PATH = RESOURCES / JSON_BZ2_NAME
 
-
 MOCK_FILES: Mapping[str, Path] = {
     TSV_URL: RESOURCES / TSV_NAME,
     JSON_URL: JSON_PATH,
@@ -124,7 +123,7 @@ class TestMocks(unittest.TestCase):
             self.assertFalse(expected_path.exists())
 
 
-class TestGet(unittest.TestCase):
+class TestJoin(unittest.TestCase):
     """Tests for :mod:`pystow`."""
 
     def setUp(self) -> None:
@@ -175,15 +174,15 @@ class TestGet(unittest.TestCase):
         :param parts: The file path parts that are joined with this test case's directory
         :return: A path to the file
         """
-        return Path(os.path.join(self.directory.name, *parts))
+        return Path(self.directory.name).joinpath(*parts)
 
     def test_mock(self):
         """Test that mocking the directory works properly for this test case."""
         with self.mock_directory():
             self.assertEqual(os.getenv(PYSTOW_HOME_ENVVAR), self.directory.name)
 
-    def test_get(self):
-        """Test the :func:`get` function."""
+    def test_join(self):
+        """Test the :func:`pystow.join` function."""
         parts_examples = [
             [n()],
             [n(), n()],
@@ -193,6 +192,39 @@ class TestGet(unittest.TestCase):
             for parts in parts_examples:
                 with self.subTest(parts=parts):
                     self.assertEqual(self.join(*parts), join(*parts))
+
+    def test_join_with_version(self):
+        """Test the join function when a version is present."""
+
+        with self.mock_directory():
+            key = "key"
+            version = "v1"
+            self.assertEqual(
+                self.join(key, version),
+                pystow.join(key, version=version),
+            )
+
+            parts = [n()]
+            self.assertEqual(
+                self.join(key, version, *parts), pystow.join(key, *parts, version=version)
+            )
+
+            parts = [n()]
+            name = "yup.tsv"
+            self.assertEqual(
+                self.join(key, version, *parts, name),
+                pystow.join(key, *parts, version=version, name=name),
+            )
+
+            def _version_getter() -> str:
+                return "v2"
+
+            parts = [n()]
+            name = "yup.tsv"
+            self.assertEqual(
+                self.join(key, _version_getter(), *parts, name),
+                pystow.join(key, *parts, version=_version_getter, name=name),
+            )
 
     def test_ensure(self):
         """Test ensuring various files."""

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -195,7 +195,6 @@ class TestJoin(unittest.TestCase):
 
     def test_join_with_version(self):
         """Test the join function when a version is present."""
-
         with self.mock_directory():
             key = "key"
             version = "v1"


### PR DESCRIPTION
This makes it easier to work with data where either you already know the version associated with it, or if you have a function that can dynamically get the version. The first time I wrote code like this was in PyOBO, but I've also written similar code many times in different places in combination with pystow, so it makes sense to enable it upstream here.

This PR just adds support for the join and ensure functions, but in a second step can be added to all functions that transitively call them.