### PR TITLE
Improve typing in `pystow.utils`

### DIFF
--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -2,6 +2,8 @@
 
 """Utilities."""
 
+from __future__ import annotations
+
 import contextlib
 import gzip
 import hashlib
@@ -105,8 +107,10 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-# Since we're python 3.6 compatible, we can't do from __future__ import annotations and use hashlib._Hash
-Hash = Any
+#: This type alias uses a stub-only constructor, meaning that
+#: hashlib._Hash isn't actually part of the code, but MyPy injects it
+#: so we can do type checking
+Hash: TypeAlias = "hashlib._Hash"
 
 HexDigestMismatch = namedtuple("HexDigestMismatch", "name actual expected")
 

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -59,6 +59,7 @@ __all__ = [
     # Data Structures and type annotations
     "HexDigestMismatch",
     "DownloadBackend",
+    "Hash",
     # Exceptions
     "HexDigestError",
     "UnexpectedDirectory",

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -27,6 +27,7 @@ from typing import (
     Collection,
     Iterable,
     Iterator,
+    Literal,
     Mapping,
     Optional,
     Union,
@@ -37,6 +38,7 @@ from uuid import uuid4
 
 import requests
 from tqdm.auto import tqdm
+from typing_extensions import TypeAlias
 
 from .constants import (
     PYSTOW_HOME_ENVVAR,
@@ -54,8 +56,9 @@ if TYPE_CHECKING:
     import rdflib
 
 __all__ = [
-    # Data Structures
+    # Data Structures and type annotations
     "HexDigestMismatch",
+    "DownloadBackend",
     # Exceptions
     "HexDigestError",
     "UnexpectedDirectory",
@@ -113,6 +116,9 @@ logger = logging.getLogger(__name__)
 Hash: TypeAlias = "hashlib._Hash"
 
 HexDigestMismatch = namedtuple("HexDigestMismatch", "name actual expected")
+
+#: Represents an available backend for downloading
+DownloadBackend = Literal["urllib", "requests"]
 
 
 class HexDigestError(ValueError):
@@ -315,7 +321,7 @@ def download(
     path: Union[str, Path],
     force: bool = True,
     clean_on_failure: bool = True,
-    backend: str = "urllib",
+    backend: DownloadBackend = "urllib",
     hexdigests: Optional[Mapping[str, str]] = None,
     hexdigests_remote: Optional[Mapping[str, str]] = None,
     hexdigests_strict: bool = False,
@@ -425,7 +431,7 @@ def download(
 class DownloadError(OSError):
     """An error that wraps information from a requests or urllib download failure."""
 
-    def __init__(self, backend: str, url: str, path: Path) -> None:
+    def __init__(self, backend: DownloadBackend, url: str, path: Path) -> None:
         """Initialize the error.
 
         :param backend: The backend used

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -112,6 +112,10 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+
+#: Represents an available backend for downloading
+DownloadBackend: TypeAlias = Literal["urllib", "requests"]
+
 #: This type alias uses a stub-only constructor, meaning that
 #: hashlib._Hash isn't actually part of the code, but MyPy injects it
 #: so we can do type checking
@@ -127,10 +131,6 @@ class HexDigestMismatch(NamedTuple):
     actual: str
     #: the expected hexdigest, encoded as a string
     expected: str
-
-
-#: Represents an available backend for downloading
-DownloadBackend: TypeAlias = Literal["urllib", "requests"]
 
 
 class HexDigestError(ValueError):

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -15,6 +15,7 @@ import shutil
 import tarfile
 import tempfile
 import urllib.error
+from typing import NamedTuple
 import zipfile
 from collections import namedtuple
 from functools import partial
@@ -116,7 +117,15 @@ logger = logging.getLogger(__name__)
 #: so we can do type checking
 Hash: TypeAlias = "hashlib._Hash"
 
-HexDigestMismatch = namedtuple("HexDigestMismatch", "name actual expected")
+class HexDigestMismatch(NamedTuple):
+    """Contains information about a hexdigest mismatch."""
+
+    #: the name of the algorithm
+    name: str
+    #: the observed/actual hexdigest, encoded as a string
+    actual: str
+    #: the expected hexdigest, encoded as a string
+    expected: str
 
 #: Represents an available backend for downloading
 DownloadBackend: TypeAlias = Literal["urllib", "requests"]

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -16,7 +16,6 @@ import tarfile
 import tempfile
 import urllib.error
 import zipfile
-from collections import namedtuple
 from functools import partial
 from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -119,7 +119,7 @@ Hash: TypeAlias = "hashlib._Hash"
 HexDigestMismatch = namedtuple("HexDigestMismatch", "name actual expected")
 
 #: Represents an available backend for downloading
-DownloadBackend = Literal["urllib", "requests"]
+DownloadBackend: TypeAlias = Literal["urllib", "requests"]
 
 
 class HexDigestError(ValueError):

--- a/src/pystow/utils.py
+++ b/src/pystow/utils.py
@@ -15,7 +15,6 @@ import shutil
 import tarfile
 import tempfile
 import urllib.error
-from typing import NamedTuple
 import zipfile
 from collections import namedtuple
 from functools import partial
@@ -30,6 +29,7 @@ from typing import (
     Iterator,
     Literal,
     Mapping,
+    NamedTuple,
     Optional,
     Union,
 )
@@ -117,6 +117,7 @@ logger = logging.getLogger(__name__)
 #: so we can do type checking
 Hash: TypeAlias = "hashlib._Hash"
 
+
 class HexDigestMismatch(NamedTuple):
     """Contains information about a hexdigest mismatch."""
 
@@ -126,6 +127,7 @@ class HexDigestMismatch(NamedTuple):
     actual: str
     #: the expected hexdigest, encoded as a string
     expected: str
+
 
 #: Represents an available backend for downloading
 DownloadBackend: TypeAlias = Literal["urllib", "requests"]


### PR DESCRIPTION
This PR does the following:

1. Adds a literal for typing the download backend
2. Modernizes the use of type stubs for type annotating hashes
3. Switches to `typing.NamedTuple` for hexdigest mismatches