### PR TITLE
Make zstd usage more defensive

### DIFF
--- a/src/pystow/api.py
+++ b/src/pystow/api.py
@@ -6,7 +6,6 @@ import bz2
 import io
 import lzma
 import sqlite3
-import sys
 import typing
 from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
@@ -18,11 +17,6 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 from .constants import JSON, Provider
 from .impl import Module, VersionHint
 from .utils.download import DownloadKwargs
-
-if sys.version_info >= (3, 14):
-    from compression import zstd
-else:
-    from backports import zstd
 
 if TYPE_CHECKING:
     import bs4
@@ -710,7 +704,7 @@ def ensure_open_zstd(
     download_kwargs: DownloadKwargs | None = None,
     mode: Literal["r", "rb", "w", "wb", "rt", "wt"] = "rt",
     open_kwargs: Mapping[str, Any] | None = None,
-) -> Generator[zstd.ZstdFile, None, None]:
+) -> Generator[io.BufferedIOBase, None, None]:
     """Ensure a zstd-compressed file is downloaded and open a file inside it.
 
     :param key: The name of the module. No funny characters. The envvar `<key>_HOME`

--- a/src/pystow/impl.py
+++ b/src/pystow/impl.py
@@ -11,7 +11,6 @@ import lzma
 import os
 import pickle
 import sqlite3
-import sys
 import tarfile
 import typing
 from collections.abc import Callable, Generator, Mapping, Sequence
@@ -42,11 +41,7 @@ from .utils import (
     read_zipfile_csv,
 )
 from .utils.download import DownloadKwargs
-
-if sys.version_info >= (3, 14):
-    from compression import zstd
-else:
-    from backports import zstd
+from .utils.safe_open import zstd_open
 
 if TYPE_CHECKING:
     import botocore.client
@@ -750,7 +745,7 @@ class Module:
         download_kwargs: DownloadKwargs | None = None,
         mode: Literal["r", "rb", "w", "wb", "rt", "wt"] = "rt",
         open_kwargs: Mapping[str, Any] | None = None,
-    ) -> Generator[zstd.ZstdFile, None, None]:
+    ) -> Generator[io.BufferedIOBase, None, None]:
         """Ensure a zSTD-compressed file is downloaded and open a file inside it.
 
         :param subkeys: A sequence of additional strings to join. If none are given,
@@ -772,7 +767,7 @@ class Module:
         )
         open_kwargs = {} if open_kwargs is None else dict(open_kwargs)
         open_kwargs.setdefault("mode", mode)
-        with zstd.open(path, **open_kwargs) as file:
+        with zstd_open(path, **open_kwargs) as file:
             yield file
 
     # docstr-coverage:excused `overload`

--- a/src/pystow/utils/safe_open.py
+++ b/src/pystow/utils/safe_open.py
@@ -15,7 +15,9 @@ import urllib.request
 import zipfile
 from collections.abc import Generator, Mapping
 from pathlib import Path
-from typing import Any, BinaryIO, Literal, Never, TextIO, TypeGuard, cast, overload
+from typing import Any, BinaryIO, Literal, TextIO, TypeGuard, cast, overload
+
+from typing_extensions import Never
 
 from .io_typing import (
     _MODE_TO_SIMPLE,

--- a/src/pystow/utils/safe_open.py
+++ b/src/pystow/utils/safe_open.py
@@ -15,7 +15,7 @@ import urllib.request
 import zipfile
 from collections.abc import Generator, Mapping
 from pathlib import Path
-from typing import Any, BinaryIO, Literal, TextIO, TypeGuard, cast, overload
+from typing import Any, BinaryIO, Literal, Never, TextIO, TypeGuard, cast, overload
 
 from .io_typing import (
     _MODE_TO_SIMPLE,
@@ -30,10 +30,20 @@ from .io_typing import (
     ensure_sensible_newline,
 )
 
-if sys.version_info >= (3, 14):
-    from compression import zstd
-else:
-    from backports import zstd
+try:
+    if sys.version_info >= (3, 14):
+        from compression import zstd
+    else:
+        from backports import zstd
+
+    zstd_open = zstd.open
+
+except ImportError:
+
+    def zstd_open(*args: Any, **kwargs: Any) -> Never:
+        """Open a Zstandard compressed file in binary or text mode."""
+        raise RuntimeError("zstd is not available")
+
 
 __all__ = [
     "is_url",
@@ -47,6 +57,7 @@ __all__ = [
     "safe_write_text",
     "write_json",
     "write_yaml",
+    "zstd_open",
 ]
 
 
@@ -140,7 +151,7 @@ def safe_open(  # noqa:C901
                 with lzma.open(path, mode=mode, encoding=encoding, newline=newline) as file:
                     yield file  # type:ignore
             elif path.suffix.endswith(".zst"):
-                with zstd.open(path, mode=mode, encoding=encoding, newline=newline) as file:
+                with zstd_open(path, mode=mode, encoding=encoding, newline=newline) as file:
                     yield file  # type:ignore
             else:
                 with open(path, mode=mode, encoding=encoding, newline=newline) as file:


### PR DESCRIPTION
Closes #155

This PR intercepts importing `zstd`, which might throw an import error if `zstd` is not available as an external dependency. It adds a mock function that raises a runtime error if called.